### PR TITLE
Added support for including endpoint descriptions in Postman collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ by adding `fast_postman_collection` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:fast_postman_collection, "~> 0.1.5"}
+    {:fast_postman_collection, "~> 0.1.7"}
   ]
 end
 ```
@@ -76,6 +76,9 @@ be found at <https://hexdocs.pm/fast_postman_collection>.
 ## Mix command for generate 
 `mix fs.get_collection`
 
+## Changelog
+- 0.1.7: Added support for including endpoint descriptions in Postman collections 
+- 0.1.6: Previous version
 
 ## How to write documenation
 

--- a/lib/fast_postman_collection/collect/collect.ex
+++ b/lib/fast_postman_collection/collect/collect.ex
@@ -93,10 +93,29 @@ defmodule FastPostmanCollection.Collect do
 
   defp documentation_body(doc) do
     case Regex.run(~r/^# (.+?)\n/, doc) do
-      [_, title] -> String.replace(doc, "# #{title}", "")
-      _any -> String.split(doc, "\n")
+      [_, title] -> 
+        # Remove the title line and trim leading whitespace
+        String.replace(doc, "# #{title}", "")
+        |> String.trim_leading()
+        |> extract_first_paragraph()
+      _any -> 
+        case String.split(doc, "\n") do
+          lines when is_list(lines) -> 
+            Enum.join(lines, "\n")
+            |> extract_first_paragraph()
+          other -> other
+        end
     end
   end
+
+  # Extract the first paragraph to use as description
+  defp extract_first_paragraph(text) when is_binary(text) do
+    case String.split(text, ~r/\n\s*\n/, parts: 2) do
+      [first_paragraph | _] -> String.trim(first_paragraph)
+      _ -> text
+    end
+  end
+  defp extract_first_paragraph(other), do: other
 
   defp documentation_handler(%{"en" => doc}), do: doc
   defp documentation_handler(:none), do: nil

--- a/lib/fast_postman_collection/generate_collection/generate_collection.ex
+++ b/lib/fast_postman_collection/generate_collection/generate_collection.ex
@@ -66,7 +66,8 @@ defmodule FastPostmanCollection.GenerateCollection do
         method: item.method,
         body: Body.generate(item),
         url: Url.generate(item),
-        auth: Auth.generate(item)
+        auth: Auth.generate(item),
+        description: item.documentation
       },
       event: Event.generate(item.doc_params)
     }

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule FastPostmanCollection.MixProject do
   def project do
     [
       app: :fast_postman_collection,
-      version: "0.1.6",
+      version: "0.1.7",
       docs: docs(),
       elixir: "~> 1.13",
       description: description(),


### PR DESCRIPTION
Noticed it wasn't pulling in descriptions as part of the exported postman collection